### PR TITLE
Fix Dockerfile build during CodeCheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ WORKDIR /src
 
 # Create a Conda environment, install the requirements, build the acceleration structures and install them
 RUN conda create -y -n htsne python=3.9.16 
+RUN conda run -n htsne conda install h5py
 RUN conda run -n htsne pip install -r requirements.txt
 RUN conda run -n htsne python setup.py build_ext --inplace \
  && conda run -n htsne pip install .


### PR DESCRIPTION
**Error:** Failed when installing dependencies (h5py) in `requirements.txt` using `pip`.
**Fix:** Install h5py using conda instead before installing other dependencies in `requirements.txt`. This fix was chosen because conda was already used to manage packages.

When building the Dockerfile, the following error occurred:
```shell
6.48 Failed to build h5py
26.48   error: subprocess-exited-with-error
26.48   
26.48   × Building wheel for h5py (pyproject.toml) did not run successfully.
26.48   │ exit code: 1
26.48   ╰─> [73 lines of output]
26.48       running bdist_wheel
26.48       running build
26.48       running build_py
26.48       creating build
26.48       creating build/lib.linux-aarch64-cpython-39
26.48       creating build/lib.linux-aarch64-cpython-39/h5py
26.48       copying h5py/h5py_warnings.py -> build/lib.linux-aarch64-cpython-39/h5py
26.48       copying h5py/version.py -> build/lib.linux-aarch64-cpython-39/h5py
26.48       copying h5py/__init__.py -> build/lib.linux-aarch64-cpython-39/h5py
26.48       copying h5py/ipy_completer.py -> build/lib.linux-aarch64-cpython-39/h5py
```